### PR TITLE
"dependsOnMethods" are used for running tests together

### DIFF
--- a/src/test/java/tests/testCase4_LogoutUser/TestCase4_LogoutUser_Mustafa.java
+++ b/src/test/java/tests/testCase4_LogoutUser/TestCase4_LogoutUser_Mustafa.java
@@ -7,7 +7,6 @@ import org.testng.annotations.Test;
 import reusableMethods.BrowserUtilities;
 import testBase.TestBaseBeforeClassAfterClass;
 import utilities.ConfigurationReader;
-
 /*Test Case 4: Logout User
 1. Launch browser
 2. Navigate to url 'http://automationexercise.com'


### PR DESCRIPTION
We want to run our test cases in a particular order in TestNG. We may use the priority parameter for that, no doubt, but priority will run all the cases without looking for the relationship we want to define (alphabetically for the same priority). 

The dependent tests in TestNG determine the dependency of a test on a single or group of tests. In this case, we say that a test is dependent on another test. It is similar to saying a browser is dependent on the internet. 